### PR TITLE
Improve Output (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ dwarf2cpp <input ELF file> <output directory>
 
 ## Customization
 You can edit [cpp.h](cpp.h) and [cpp.cpp](cpp.cpp) to customize how the C/C++ output is generated. Currently, there are no customization options that can be passed as command line arguments to this tool.
+
+## DWARFv1 Documentation
+Useful References:  
+ - http://www.dwarfstd.org/doc/dwarf_1_1_0.pdf

--- a/cpp.h
+++ b/cpp.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "dwarf.h"
 #include <vector>
 #include <map>
 #include <string>
@@ -70,6 +71,8 @@ struct Type
 		UserType *userType;
 	};
 
+	int size();
+	std::string toString(std::string varName);
 	std::string toString();
 	static std::string ModifierToString(Modifier m);
 };
@@ -85,7 +88,7 @@ struct Variable
 
 struct UserType
 {
-	enum { CLASS, ENUM, ARRAY, FUNCTION } type;
+	enum { CLASS, UNION, STRUCT, ENUM, ARRAY, FUNCTION } type;
 	std::string name;
 	int index;
 
@@ -109,6 +112,8 @@ struct ClassType
 		int offset;
 		std::string name;
 		Type type;
+		int bit_offset;
+		int bit_size;
 
 		std::string toString(bool includeOffset);
 	};
@@ -119,9 +124,11 @@ struct ClassType
 		Type type;
 	};
 
+	UserType* parent;
 	int size;
 	std::vector<Member> members;
 	std::vector<Inheritance> inheritances;
+	std::vector<Function> functions;
 
 	std::string toNameString(std::string name, bool includeSize, bool includeInheritances);
 	std::string toBodyString(bool includeOffsets);
@@ -133,11 +140,12 @@ struct EnumType
 	struct Element
 	{
 		std::string name;
-		int constValue;
+		long constValue;
 
 		std::string toString(int lastValue);
 	};
 
+	FundamentalType baseType;
 	std::vector<Element> elements;
 
 	std::string toNameString(std::string name);
@@ -176,18 +184,23 @@ struct FunctionType
 
 struct Function : FunctionType
 {
+
 	bool isGlobal;
 	std::string name;
 	std::string mangledName;
 	unsigned int startAddress;
 	std::vector<Variable> variables;
+	UserType* typeOwner;
+	Dwarf* dwarf;
 
 	std::string toNameString();
+	std::string toNameString(bool skipNamespace);
 	std::string toDeclarationString();
 	std::string toDefinitionString();
 };
 
 std::string FundamentalTypeToString(FundamentalType ft);
+int GetFundamentalTypeSize(FundamentalType ft);
 std::string CommentToString(std::string comment);
 std::string StarCommentToString(std::string comment, bool multiline);
 std::string IndentToString(int level);

--- a/main.cpp
+++ b/main.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <vector>
 #include <map>
+#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
 #include <experimental/filesystem>
 
 namespace filesystem = std::experimental::filesystem;
@@ -31,7 +32,7 @@ bool processClassType(Dwarf::Entry *entry, Cpp::ClassType *c);
 bool processMember(Dwarf::Entry *entry, Cpp::ClassType::Member *m);
 bool processInheritance(Dwarf::Entry *entry, Cpp::ClassType::Inheritance *i_);
 bool processEnumType(Dwarf::Entry *entry, Cpp::EnumType *e);
-bool processElementList(Dwarf::Attribute *attr, Cpp::EnumType *e);
+bool processElementList(Dwarf::Attribute *attr, Cpp::EnumType *e, int byte_size);
 bool processFunctionType(Dwarf::Entry *entry, Cpp::FunctionType *f);
 bool processParameter(Dwarf::Entry *entry, Cpp::FunctionType::Parameter *p);
 bool processFunction(Dwarf::Entry *entry, Cpp::Function *f);
@@ -39,6 +40,18 @@ bool processLexicalBlock(Dwarf::Entry *entry, Cpp::Function *f);
 bool processArrayType(Dwarf::Entry *entry, Cpp::ArrayType *a);
 bool processSubscriptData(Dwarf::Attribute *attr, Cpp::ArrayType *a);
 void replaceChar(char *str, char ch, char newCh);
+
+static inline std::string toHexString(int x)
+{
+	std::stringstream ss;
+	ss << std::hex << std::showbase << x;
+	return ss.str();
+}
+
+bool error(std::string errorMessage) {
+	std::cout << "ERROR: " << errorMessage << std::endl;
+	return false;
+}
 
 int main(int argc, char **argv)
 {
@@ -55,20 +68,26 @@ int main(int argc, char **argv)
 
 	ElfFile *elf = new ElfFile(elfFilename);
 
-	if (elf->getError())
+	if (elf->getError()) {
+		std::cout << "Failed to parse " << elfFilename << " as an ELF file. Error Code: " << elf->getError() << std::endl;
 		return 1;
+	}
 
 	std::cout << "Loading DWARFv1 information..." << std::endl;
 
 	Dwarf *dwarf = new Dwarf(elf);
 
-	if (dwarf->getError())
+	if (dwarf->getError()) {
+		std::cout << "Failed to parse DWARF data. Error Code: " << dwarf->getError() << std::endl;
 		return 1;
+	}
 
 	std::cout << "Converting DWARFv1 entries to C++ data..." << std::endl;
 
-	if (!processDwarf(dwarf))
+	if (!processDwarf(dwarf)) {
+		std::cout << "Failed to process DWARF data." << std::endl;
 		return 1;
+	}
 
 	std::cout << "Done converting DWARFv1 data!" << std::endl;
 	std::cout << "\tNumber of C++ files: " << cppFiles.size() << std::endl << std::endl;
@@ -174,7 +193,7 @@ bool processDwarf(Dwarf *dwarf)
 			}
 
 			if (!processCompileUnit(entry, cpp))
-				return false;
+				return error(std::string("Failed to processCompileUnit for '").append(cpp->filename).append("'"));
 
 			if (!found)
 				cppFiles.push_back(cpp);
@@ -243,7 +262,7 @@ bool processCompileUnit(Dwarf::Entry *entry, Cpp::File *cpp)
 			Cpp::Variable var;
 
 			if (!processVariable(entry, &var))
-				return false;
+				return error("Failed to processVar.");
 
 			cpp->variables.push_back(var);
 			break;
@@ -269,12 +288,13 @@ bool processCompileUnit(Dwarf::Entry *entry, Cpp::File *cpp)
 		case DW_TAG_inlined_subroutine:
 		{
 			Cpp::Function f;
+			f.dwarf = entry->dwarf;
 
 			if (!processFunctionType(entry, &f))
-				return false;
+				return error("Failed to processFunctionType.");
 
 			if (!processFunction(entry, &f))
-				return false;
+				return error("Failed to processFunction.");
 
 			cpp->functions.push_back(f);
 		}
@@ -306,7 +326,7 @@ bool processVariable(Dwarf::Entry *entry, Cpp::Variable *var)
 		case DW_AT_mod_fund_type:
 		case DW_AT_mod_u_d_type:
 			if (!processTypeAttr(attr, &var->type))
-				return false;
+				return error(std::string("Failed to processTypeAttr for variable '").append(var->name).append("'."));
 			break;
 		}
 	}
@@ -331,7 +351,7 @@ bool processTypeAttr(Dwarf::Attribute *attr, Cpp::Type *type)
 		type->isFundamentalType = false;
 
 		if (!findUserType(dwarf, attr->getReference(), &type->userType))
-			return false;
+			return error(std::string("processTypeAttr failed when handling AT_user_def_type."));
 
 		break;
 	}
@@ -360,7 +380,7 @@ bool processTypeAttr(Dwarf::Attribute *attr, Cpp::Type *type)
 		char *end = mod + attr->size - sizeof(Elf32_Off);
 
 		if (!findUserType(dwarf, dwarf->read<Elf32_Off>(end), &type->userType))
-			return false;
+			return error(std::string("processTypeAttr failed when handling AT_mod_u_d_type."));
 
 		while (mod < end)
 		{
@@ -405,7 +425,7 @@ bool findUserType(Dwarf *dwarf, Elf32_Off ref, Cpp::UserType **u)
 	Dwarf::Entry *entry = dwarf->getEntryFromReference(ref);
 
 	if (!entry || entryUTPairs.count(entry) == 0)
-		return false;
+		return error(std::string("Failed to findUserType for reference '").append(std::to_string(ref)).append("'."));
 
 	*u = entryUTPairs[entry];
 
@@ -435,11 +455,12 @@ bool processUserType(Dwarf::Entry *entry, Cpp::UserType *userType)
 	case DW_TAG_class_type:
 	case DW_TAG_structure_type:
 	case DW_TAG_union_type:
-		userType->type = Cpp::UserType::CLASS;
+		userType->type = (entry->tag == DW_TAG_structure_type) ? Cpp::UserType::STRUCT : ((entry->tag == DW_TAG_union_type) ? Cpp::UserType::UNION : Cpp::UserType::CLASS);
 		userType->classData = new Cpp::ClassType;
+		userType->classData->parent = userType;
 
 		if (!processClassType(entry, userType->classData))
-			return false;
+			return error(std::string("Failed to processClassType for user type '").append(userType->name).append("'."));
 
 		break;
 	case DW_TAG_enumeration_type:
@@ -447,7 +468,7 @@ bool processUserType(Dwarf::Entry *entry, Cpp::UserType *userType)
 		userType->enumData = new Cpp::EnumType;
 
 		if (!processEnumType(entry, userType->enumData))
-			return false;
+			return error(std::string("Failed to processEnumType for user type '").append(userType->name).append("'."));
 
 		break;
 	case DW_TAG_array_type:
@@ -455,7 +476,7 @@ bool processUserType(Dwarf::Entry *entry, Cpp::UserType *userType)
 		userType->arrayData = new Cpp::ArrayType;
 
 		if (!processArrayType(entry, userType->arrayData))
-			return false;
+			return error(std::string("Failed to processArrayType for array type '").append(userType->name).append("'."));
 
 		break;
 	case DW_TAG_subroutine_type:
@@ -463,7 +484,7 @@ bool processUserType(Dwarf::Entry *entry, Cpp::UserType *userType)
 		userType->functionData = new Cpp::FunctionType;
 
 		if (!processFunctionType(entry, userType->functionData))
-			return false;
+			return error(std::string("Failed to processFunctionType for function type '").append(userType->name).append("'."));
 
 		break;
 	}
@@ -513,7 +534,7 @@ bool processClassType(Dwarf::Entry *entry, Cpp::ClassType *c)
 			Cpp::ClassType::Member m;
 
 			if (!processMember(entry, &m))
-				return false;
+				return error("Failed to processMember for class type.");
 
 			c->members.push_back(m);
 			break;
@@ -522,7 +543,7 @@ bool processClassType(Dwarf::Entry *entry, Cpp::ClassType *c)
 			Cpp::ClassType::Inheritance i;
 
 			if (!processInheritance(entry, &i))
-				return false;
+				return error("Failed to processInheritance for class type.");
 
 			c->inheritances.push_back(i);
 			break;
@@ -536,6 +557,8 @@ bool processClassType(Dwarf::Entry *entry, Cpp::ClassType *c)
 
 bool processMember(Dwarf::Entry *entry, Cpp::ClassType::Member *m)
 {
+	m->bit_offset = -1;
+	m->bit_size = -1;
 	for (int i = 0; i < entry->numAttributes; i++)
 	{
 		Dwarf::Attribute *attr = &entry->attributes[i];
@@ -545,16 +568,22 @@ bool processMember(Dwarf::Entry *entry, Cpp::ClassType::Member *m)
 		case DW_AT_name:
 			m->name = attr->getString();
 			break;
+		case DW_AT_bit_offset:
+			m->bit_offset = attr->getHword();
+			break;
+		case DW_AT_bit_size:
+			m->bit_size = attr->getWord();
+			break;
 		case DW_AT_fund_type:
 		case DW_AT_user_def_type:
 		case DW_AT_mod_fund_type:
 		case DW_AT_mod_u_d_type:
 			if (!processTypeAttr(attr, &m->type))
-				return false;
+				return error(std::string("Failed to processTypeAttr for member '").append(m->name).append("'."));
 			break;
 		case DW_AT_location:
 			if (!processLocationAttr(attr, &m->offset))
-				return false;
+				return error(std::string("Failed to processLocationAttr for member '").append(m->name).append("'."));
 		}
 	}
 
@@ -571,11 +600,11 @@ bool processInheritance(Dwarf::Entry *entry, Cpp::ClassType::Inheritance *i_)
 		{
 		case DW_AT_user_def_type:
 			if (!processTypeAttr(attr, &i_->type))
-				return false;
+				return error("Failed to processTypeAttr for inheritance.");
 			break;
 		case DW_AT_location:
 			if (!processLocationAttr(attr, &i_->offset))
-				return false;
+				return error("Failed to processLocationAttr for inheritance.");
 		}
 	}
 
@@ -584,15 +613,37 @@ bool processInheritance(Dwarf::Entry *entry, Cpp::ClassType::Inheritance *i_)
 
 bool processEnumType(Dwarf::Entry *entry, Cpp::EnumType *e)
 {
+	int byte_size = 0;
 	for (int i = 0; i < entry->numAttributes; i++)
 	{
 		Dwarf::Attribute *attr = &entry->attributes[i];
 
 		switch (attr->name)
 		{
+		case DW_AT_byte_size:
+			byte_size = attr->getWord();
+
+			switch (byte_size) {
+			case 1:
+				e->baseType = Cpp::FundamentalType::UNSIGNED_CHAR;
+				break;
+			case 2:
+				e->baseType = Cpp::FundamentalType::UNSIGNED_SHORT;
+				break;
+			case 4:
+				e->baseType = Cpp::FundamentalType::INT;
+				break;
+			case 8:
+				e->baseType = Cpp::FundamentalType::LONG;
+				break;
+			default:
+				return error(std::string("Unknown enum base type size for enum type. (Size: ").append(std::to_string(byte_size)).append(")"));
+				break;
+			}
+			break;
 		case DW_AT_element_list:
-			if (!processElementList(attr, e))
-				return false;
+			if (!processElementList(attr, e, byte_size))
+				return error("Failed to processElementList for enum type.");
 			break;
 		}
 	}
@@ -600,7 +651,7 @@ bool processEnumType(Dwarf::Entry *entry, Cpp::EnumType *e)
 	return true;
 }
 
-bool processElementList(Dwarf::Attribute *attr, Cpp::EnumType *e)
+bool processElementList(Dwarf::Attribute *attr, Cpp::EnumType *e, int byte_size)
 {
 	Dwarf *dwarf = attr->entry->dwarf;
 
@@ -611,8 +662,20 @@ bool processElementList(Dwarf::Attribute *attr, Cpp::EnumType *e)
 	{
 		Cpp::EnumType::Element element;
 
-		element.constValue = dwarf->read<int>(block);
-		block += sizeof(int);
+		if (byte_size == 1) {
+			element.constValue = dwarf->read<unsigned char>(block);
+		}
+		else if (byte_size == 2) {
+			element.constValue = dwarf->read<unsigned short>(block);
+		}
+		else if (byte_size == 4) {
+			element.constValue = dwarf->read<int>(block);
+		}
+		else if (byte_size == 8) {
+			element.constValue = dwarf->read<long>(block);
+		}
+		
+		block += byte_size;
 
 		element.name = block;
 		block += element.name.size() + 1;
@@ -653,7 +716,7 @@ bool processFunctionType(Dwarf::Entry *entry, Cpp::FunctionType *f)
 		case DW_AT_mod_fund_type:
 		case DW_AT_mod_u_d_type:
 			if (!processTypeAttr(attr, &f->returnType))
-				return false;
+				return error("Failed to processTypeAttr for function return type.");
 			break;
 		}
 	}
@@ -668,7 +731,7 @@ bool processFunctionType(Dwarf::Entry *entry, Cpp::FunctionType *f)
 			Cpp::FunctionType::Parameter p;
 
 			if (!processParameter(entry, &p))
-				return false;
+				return error("Failed to processParameter for function parameter.");
 
 			f->parameters.push_back(p);
 		}
@@ -695,7 +758,7 @@ bool processParameter(Dwarf::Entry *entry, Cpp::FunctionType::Parameter *p)
 		case DW_AT_mod_fund_type:
 		case DW_AT_mod_u_d_type:
 			if (!processTypeAttr(attr, &p->type))
-				return false;
+				return error(std::string("Failed to processTypeAttr for parameter '").append(p->name).append("'."));
 			break;
 		}
 	}
@@ -735,10 +798,70 @@ bool processFunction(Dwarf::Entry *entry, Cpp::Function *f)
 		{
 		case DW_TAG_lexical_block:
 			if (!processLexicalBlock(entry, f))
-				return false;
+				return error(std::string("Failed to processLexicalBlock for function '").append(f->name).append("'."));
 		}
 
 		entry = entry->getSibling();
+	}
+
+	f->typeOwner = nullptr;
+	if (f->parameters.size() > 0 && f->parameters[0].name.compare("this") == 0) {
+		f->typeOwner = f->parameters[0].type.userType;
+		f->parameters.erase(f->parameters.begin());
+		f->typeOwner->classData->functions.push_back(*f);
+	}
+	else if (f->mangledName.size() > 2) {
+		int foundAt = f->mangledName.find_last_of("__");
+		if (foundAt != -1) {
+			char temp;
+			std::stringstream length;
+			int i;
+			for (i = foundAt + 1; i < f->mangledName.size(); i++) {
+				temp = f->mangledName[i];
+				if (temp >= '0' && temp <= '9') {
+					length << temp;
+				}
+				else {
+					break;
+				}
+			}
+
+			std::string lengthStr = length.str();
+			if (lengthStr.length() > 0) {
+				int lengthCount = std::stoi(lengthStr);
+				if (f->mangledName[i + lengthCount] == 'F') {
+					std::string className = f->mangledName.substr(i, lengthCount);
+
+					// I tried to access this from the named map, but I couldn't for the life of me figure out how to do it. C++ is terrible, no other languages have runtime libraries that silently fail like this. The map is empty even though the code that adds elements to the map is run. Good grief.
+					/*auto it = nameUTListPairs.find(className);
+					if (it != nameUTListPairs.end()) {
+						std::vector<Cpp::UserType*> vector = it->second;
+						if (vector.size() != 1)
+							std::cout << "Couldn't find good type for '" << className << "'. (" << vector.size() << ")" << std::endl;
+					}
+					else {
+						std::cout << "Couldn't find good type for '" << className << "'." << std::endl;
+					}*/
+						
+					
+					Cpp::UserType* type = nullptr;
+					for (std::map<Dwarf::Entry*, Cpp::UserType*>::iterator iter = entryUTPairs.begin(); iter != entryUTPairs.end(); ++iter)
+					{
+						Dwarf::Entry* k = iter->first;
+						Cpp::UserType* value = iter->second;
+						if (value->name.compare(className) == 0) {
+							type = value;
+							break;
+						}
+					}
+
+					if (type != nullptr) {
+						f->typeOwner = type;
+						f->typeOwner->classData->functions.push_back(*f);
+					}
+				}
+			}
+		}
 	}
 
 	return true;
@@ -760,7 +883,7 @@ bool processLexicalBlock(Dwarf::Entry *entry, Cpp::Function *f)
 			Cpp::Variable v;
 			
 			if (!processVariable(entry, &v))
-				return false;
+				return error(std::string("Failed to processVariable for local var lexical block in function '").append(f->name).append("'."));
 
 			f->variables.push_back(v);
 			break;
@@ -783,11 +906,11 @@ bool processArrayType(Dwarf::Entry *entry, Cpp::ArrayType *a)
 		{
 		case DW_AT_ordering:
 			if (attr->getHword() != DW_ORD_row_major) // meh
-				return false;
+				return error(std::string("processArrayType encountered ordering unsupported by dwarf2cpp! (").append(toHexString(attr->getHword())).append(")"));
 			break;
 		case DW_AT_subscr_data:
 			if (!processSubscriptData(attr, a))
-				return false;
+				return error("Failed to processSubscriptData.");
 		}
 	}
 
@@ -815,7 +938,7 @@ bool processSubscriptData(Dwarf::Attribute *attr, Cpp::ArrayType *a)
 			block = dwarf->offsetToPointer(offset);
 
 			if (!processTypeAttr(typeAttr, &a->type))
-				return false;
+				return error("Failed to processTypeAttr for subscript data DW_FMT_ET.");
 
 			break;
 		}
@@ -826,14 +949,14 @@ bool processSubscriptData(Dwarf::Attribute *attr, Cpp::ArrayType *a)
 
 			// Only long indices are supported
 			if (fundType != DW_FT_long)
-				return false;
+				return error(std::string("Subscript data DW_FMT_FT_C_C had unsupported fundamental indice type ").append(toHexString(fundType)).append(" in type '").append(a->toNameString("")).append("'."));
 
 			Elf32_Word lowBound = dwarf->read<Elf32_Word>(block);
 			block += sizeof(Elf32_Word);
 
 			// Only indices starting at 0 are supported
 			if (lowBound != 0)
-				return false;
+				return error(std::string("Subscript data contained indices which did not start at zero! (Start at: '").append(toHexString(lowBound)).append("', Type: '").append(a->toNameString("")).append("')"));
 
 			Elf32_Word highBound = dwarf->read<Elf32_Word>(block);
 			block += sizeof(Elf32_Word);
@@ -847,7 +970,7 @@ bool processSubscriptData(Dwarf::Attribute *attr, Cpp::ArrayType *a)
 		{
 			// Only fundamental typed (long) indices and
 			// constant value bounds are supported
-			return false;
+			return error(std::string("Encountered subscript data format unsupported by dwarf2cpp! (").append(toHexString(format)).append(")"));
 		}
 	}
 


### PR DESCRIPTION
* Make buildable in VS2019.

* Export correct struct/class/union, and link class functions to class.

* Fix enum types, include struct bit configuration.

* Fixed truncation of enum names.

* Parse line numbers and include them in exported functions.

* Avoid using type_ types when possible.

* Verbose failure messages. Don't exit dwarf2cpp without a message explaining why.